### PR TITLE
Typo: PositionOptions is a dictionary rather than an interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -658,7 +658,7 @@
       <section id="position_options_interface" data-dfn-for="PositionOptions"
       data-link-for="PositionOptions">
         <h3>
-          <dfn>PositionOptions</dfn> interface
+          <dfn>PositionOptions</dfn> dictionary
         </h3>
         <p>
           The <a data-link-for="Geolocation">getCurrentPosition()</a> and


### PR DESCRIPTION
Minor fix: the PositionOptions dictionary definition was labelled as an interface.

I left the ID as `position_options_interface` deliberately. There seem to be a lot of scattered links around pointing to it and I figured it was better to err on the side of leaving those links working.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bathos/geolocation-api/pull/38.html" title="Last updated on Nov 24, 2019, 5:39 AM UTC (89d4ce0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/38/a11d0d0...bathos:89d4ce0.html" title="Last updated on Nov 24, 2019, 5:39 AM UTC (89d4ce0)">Diff</a>