### PR TITLE
fix: callbacks are not EventHandlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>
       Geolocation API Specification
     </title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c' async
-    class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=
+    'remove'></script>
     <script class='remove'>
     var respecConfig = {
       shortName: "geolocation-API",
@@ -426,10 +426,9 @@
           arguments. When called, it MUST immediately return and then
           asynchronously attempt to obtain the current location of the device.
           If the attempt is successful, the <var>successCallback</var> MUST be
-          invoked (i.e. the {{EventListener/handleEvent()}} operation MUST be
-          called on the callback object) with a new <a>GeolocationPosition</a>
-          object, reflecting the current location of the device. If the attempt
-          fails, the <var>errorCallback</var> MUST be invoked with a new
+          invoked with a new <a>GeolocationPosition</a> object, reflecting the
+          current location of the device. If the attempt fails, the
+          <var>errorCallback</var> MUST be invoked with a new
           <a>GeolocationPositionError</a> object, reflecting the reason for the
           failure.
         </p>
@@ -521,10 +520,8 @@
               Otherwise, start the watch operation. This operation MUST first
               attempt to obtain the current location of the device. If the
               attempt is successful, the <var>successCallback</var> MUST be
-              invoked (i.e. the {{EventListener/handleEvent()}} operation MUST
-              be called on the callback object) with a new
-              <a>GeolocationPosition</a> object, reflecting the current
-              location of the device. If the attempt fails, the
+              invoked with a new <a>GeolocationPosition</a> object, reflecting
+              the current location of the device. If the attempt fails, the
               <var>errorCallback</var> MUST be invoked with a new
               <a>GeolocationPositionError</a> object, reflecting the reason for
               the failure. The <a>watch process</a> then MUST continue to


### PR DESCRIPTION
Closes #24

The following tasks have been completed:

 * [X] Modified Web platform tests: there are not tests in WPT for this, thankfully. 

Implementation commitment:

 * [X] WebKit 
 * [X] Chromium 
 * [X] Gecko

Checked all three browsers, no one supports what was in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 21, 2020, 6:32 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fgeolocation-api%2Fpull%2F39%2F3341e1e.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fgeolocation-api%2Fpull%2F39.html)

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
<head><title>HTML Diff service</title>
<link rel="stylesheet" href="http://www.w3.org/StyleSheets/base" />
</head>
<body>

<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C"/></a> <a href="http://www.w3.org/2003/Editors">W3C Editors homepage</a></p>

<h1>Create Diff between HTML pages</h1>

<p style='color:#FF0000'>An error (403 Forbidden) occured trying to get <a href='https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/39/3341e1e.html'>https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/39/3341e1e.html</a>.</p>

<form method="GET">
<p>Address of reference document: <input name="doc1" type="url" value="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/39/3341e1e.html" style="width:100%"/></p>
<p>Address of new document: <input name="doc2" value="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/39.html"  style="width:100%"/></p>
<p><input type="submit" value="get Diff"/></p>
</form>

<p><strong>Tip</strong>: if the document uses the W3C convention on linking to its previous version, you can specify only the address of the new document — the previous link will be automatically detected.</p>
<h2>Diff markings</h2>
<p>This service relies on <a href="https://www.gnu.org/software/diffutils/">GNU diff</a>. The found differences are roughly marked as follow:
<ul>
<li>deleted text is shown in pink with down-arrows (as styled for a &lt;del> element)</li>
<li>where there is replacement, it’s shown in green with bi-directional arrows,</li>
<li>where there is newly inserted text, it’s yellow with up arrows (&lt;ins> element)</li>
</ul>
<address>
script $Revision$ of $Date$<br />
by <a href="http://www.w3.org/People/Dom/">Dominique Hazaël-Massieux</a><br />based on <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff.pl">Shane McCarron’ Perl script</a> wrapped in a <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff">Python CGI</a>
</address>
</body>
</html>


```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/geolocation-api%2339.)._
</details>
