### PR TITLE
Editorial: remove RFC2119 words from Requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,38 +1095,38 @@
           </p>
         </section>
       </section>
-      <section id="requirements_section">
+      <section id="requirements_section" class="informative">
         <h3>
           Requirements
         </h3>
         <ol>
-          <li id="req_latlong">The Geolocation API MUST provide location data
-          in terms of a pair of latitude and longitude coordinates.
+          <li id="req_latlong">The Geolocation API needs to provide location
+          data in terms of a pair of latitude and longitude coordinates.
           </li>
-          <li id="req_accuracy">The Geolocation API MUST provide information
-          about the accuracy of the retrieved location data.
+          <li id="req_accuracy">The Geolocation API needs to provide
+          information about the accuracy of the retrieved location data.
           </li>
-          <li id="req_oneshot">The Geolocation API MUST support "one-shot"
+          <li id="req_oneshot">The Geolocation API needs to support "one-shot"
           position updates.
           </li>
-          <li id="req_updates">The Geolocation API MUST allow an application to
-          register to receive updates when the position of the hosting device
-          changes.
+          <li id="req_updates">The Geolocation API needs to allow an
+          application to register to receive updates when the position of the
+          hosting device changes.
           </li>
-          <li id="req_last_known">The Geolocation API MUST allow an application
-          to request a cached position whose age is no greater than a specified
-          value.
+          <li id="req_last_known">The Geolocation API needs to allow an
+          application to request a cached position whose age is no greater than
+          a specified value.
           </li>
-          <li id="req_errors">The Geolocation API MUST provide a way for the
-          application to receive updates about errors that MAY have occurred
+          <li id="req_errors">The Geolocation API needs to provide a way for
+          the application to receive updates about errors that have occurred
           while obtaining a location fix.
           </li>
-          <li id="req_request_acuracy">The Geolocation API MUST allow an
+          <li id="req_request_acuracy">The Geolocation API needs to allow an
           application to specify a desired accuracy level of the location
           information.
           </li>
-          <li id="req_source_agnostic">The Geolocation API MUST be agnostic to
-          the underlying sources of location information.
+          <li id="req_source_agnostic">The Geolocation API needs to be agnostic
+          to the underlying sources of location information.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
Closes #56


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/63.html" title="Last updated on Mar 22, 2021, 1:33 AM UTC (3518ac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/63/c0381e2...3518ac5.html" title="Last updated on Mar 22, 2021, 1:33 AM UTC (3518ac5)">Diff</a>