### PR TITLE
MUST have express permission to share location

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
         information also discloses the location of the user of the device,
         thereby potentially compromising the user's privacy. A conforming
         implementation of this specification MUST provide a mechanism that
-        protects the user's privacy and this mechanism SHOULD ensure that no
+        protects the user's privacy and this mechanism MUST ensure that no
         location information is made available through this API without the
         user's express permission.
       </p>


### PR DESCRIPTION
Closes #54

Implementation commitment:

 * [X] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [X] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

All implementations always ask for permission.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/64.html" title="Last updated on Mar 22, 2021, 1:40 AM UTC (2d6ccf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/64/c0381e2...2d6ccf1.html" title="Last updated on Mar 22, 2021, 1:40 AM UTC (2d6ccf1)">Diff</a>