### PR TITLE
Editorial: recipients are not a conformance class

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
           Privacy considerations for recipients of location information
         </h3>
         <p class="note" title=
-        "Developers responsibility with this sensitive data">
+        "Developers' responsibility with this sensitive data">
           This section applies to "recipients", which generally means
           developers utilizing the <cite>Geolocation API</cite>. Although it's
           impossible for user agent or specification to enforce these

--- a/index.html
+++ b/index.html
@@ -284,33 +284,43 @@
           using location information to perform an E911 function.
         </p>
       </section>
-      <section id="privacy_for_recipients">
+      <section id="privacy_for_recipients" class="informative">
         <h3>
           Privacy considerations for recipients of location information
         </h3>
+        <p class="note" title=
+        "Developers responsibility with this sensitive data">
+          This section applies to "recipients", which generally means
+          developers utilizing the <cite>Geolocation API</cite>. Although it's
+          impossible for user agent or specification to enforce these
+          requirements, developers need to read this section carefully and do
+          their best to adhere to the recommendations below. Developers should
+          also be aware that privacy laws in their jurisdictions can also
+          govern the usage and access to location data.
+        </p>
         <p>
-          Recipients MUST only request location information when necessary.
-          Recipients MUST only use the location information for the task for
-          which it was provided to them. Recipients MUST dispose of location
+          Recipients must only request location information when necessary.
+          Recipients must only use the location information for the task for
+          which it was provided to them. Recipients must dispose of location
           information once that task is completed, unless expressly permitted
-          to retain it by the user. Recipients MUST also take measures to
+          to retain it by the user. Recipients must also take measures to
           protect this information against unauthorized access. If location
-          information is stored, users SHOULD be allowed to update and delete
+          information is stored, users should be allowed to update and delete
           this information.
         </p>
         <p>
-          The recipient of location information MUST NOT retransmit the
+          The recipient of location information must not retransmit the
           location information without the user’s express permission. Care
-          SHOULD be taken when retransmitting and use of encryption is
+          should be taken when retransmitting and use of encryption is
           encouraged.
         </p>
         <p>
-          Recipients MUST clearly and conspicuously disclose the fact that they
+          Recipients must clearly and conspicuously disclose the fact that they
           are collecting location data, the purpose for the collection, how
           long the data is retained, how the data is secured, how the data is
-          shared if it is shared, how users MAY access, update and delete the
+          shared if it is shared, how users can access, update and delete the
           data, and any other choices that users have with respect to the data.
-          This disclosure MUST include an explanation of any exceptions to the
+          This disclosure must include an explanation of any exceptions to the
           guidelines listed above.
         </p>
       </section>
@@ -321,8 +331,8 @@
         <p>
           Further to the requirements listed in the previous section,
           implementers of the Geolocation API are also advised to consider the
-          following aspects that MAY negatively affect the privacy of their
-          users: in certain cases, users MAY inadvertently grant permission to
+          following aspects that can negatively affect the privacy of their
+          users: in certain cases, users can inadvertently grant permission to
           the user agent to disclose their location to Web sites. In other
           cases, the content hosted at a certain URL changes in such a way that
           the previously granted location permissions no longer apply as far as

--- a/index.html
+++ b/index.html
@@ -299,29 +299,29 @@
           govern the usage and access to location data.
         </p>
         <p>
-          Recipients must only request location information when necessary.
-          Recipients must only use the location information for the task for
-          which it was provided to them. Recipients must dispose of location
-          information once that task is completed, unless expressly permitted
-          to retain it by the user. Recipients must also take measures to
-          protect this information against unauthorized access. If location
-          information is stored, users should be allowed to update and delete
-          this information.
+          Recipients ought to only request location information when necessary,
+          and only use the location information for the task for which it was
+          provided to them. Recipients ought to dispose of location information
+          once that task is completed, unless expressly permitted to retain it
+          by the user. Recipients need to also take measures to protect this
+          information against unauthorized access. If location information is
+          stored, users need to be allowed to update and delete this
+          information.
         </p>
         <p>
-          The recipient of location information must not retransmit the
-          location information without the user’s express permission. Care
-          should be taken when retransmitting and use of encryption is
-          encouraged.
+          The recipient of location information need to refrain from
+          retransmitting the location information without the user’s express
+          permission. Care needs to be taken when retransmitting and the use of
+          encryption is encouraged.
         </p>
         <p>
-          Recipients must clearly and conspicuously disclose the fact that they
-          are collecting location data, the purpose for the collection, how
-          long the data is retained, how the data is secured, how the data is
-          shared if it is shared, how users can access, update and delete the
-          data, and any other choices that users have with respect to the data.
-          This disclosure must include an explanation of any exceptions to the
-          guidelines listed above.
+          Recipients ought to clearly and conspicuously disclose the fact that
+          they are collecting location data, the purpose for the collection,
+          how long the data is retained, how the data is secured, how the data
+          is shared if it is shared, how users can access, update and delete
+          the data, and any other choices that users have with respect to the
+          data. This disclosure needs to include an explanation of any
+          exceptions to the guidelines listed above.
         </p>
       </section>
       <section id="implementation_considerations" class="informative">

--- a/index.html
+++ b/index.html
@@ -294,8 +294,8 @@
           developers utilizing the <cite>Geolocation API</cite>. Although it's
           impossible for user agent or specification to enforce these
           requirements, developers need to read this section carefully and do
-          their best to adhere to the recommendations below. Developers should
-          also be aware that privacy laws in their jurisdictions can also
+          their best to adhere to the recommendations below. Developers also
+          need to be aware of any privacy laws in their jurisdictions that
           govern the usage and access to location data.
         </p>
         <p>


### PR DESCRIPTION
Addresses https://github.com/w3ctag/design-reviews/issues/529


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/66.html" title="Last updated on Mar 23, 2021, 6:58 AM UTC (9e8c701)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/66/6256b91...9e8c701.html" title="Last updated on Mar 23, 2021, 6:58 AM UTC (9e8c701)">Diff</a>