### PR TITLE
chore(github/workflows/pr-push): autopub

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -1,0 +1,22 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - gh-pages
+  pull_request: {}
+
+jobs:
+  validate-and-publish:
+    name: Validate and Publish
+    runs-on: ubuntu-latest # only linux supported at present
+    steps:
+      - uses: actions/checkout@v2
+      - uses: sidvishnoi/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-device-apis/2021May/0008.html"
+          W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD


### PR DESCRIPTION
For when the document is up on TR, we can start auto-publishing. 