### PR TITLE
Gracefully handle documents that are not fully active

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,8 @@
     };
     </script>
   </head>
-  <body data-cite="secure-contexts permissions-policy permissions page-visibility-2">
+  <body data-cite=
+  "secure-contexts permissions-policy permissions page-visibility-2">
     <section id="abstract">
       <p>
         The Geolocation API provides access to geographical location
@@ -599,18 +600,7 @@
           {{long}}.
           </li>
           <li>Let |watchTasks:Set| be [=this=]'s
-            {{Geolocation/[[watchTasks]]}}.
-            </li>
-          <li>
-            If the [=current settings object=]'s [=associated `Document`=] is not [=fully active=]:
-            <ol>
-              <li>
-                [=list/Empty=] |watchTasks|.
-              </li>
-              <li>
-                Return [=implementation-defined=] {{long}}.
-              </li>
-            </ol>
+          {{Geolocation/[[watchTasks]]}}.
           </li>
           <li>If |previousId| was provided, let |watchId:long| be |previousId|;
           Otherwise, let |watchId:long| be an [=implementation-defined=]
@@ -639,8 +629,7 @@
                   </li>
                 </ol>
               </li>
-              <li>Wait for document to become
-              visible.
+              <li>Wait for document to become visible.
                 <ol>
                   <li>Let |document:Document| be the [=current settings
                   object=]'s [=associated Document=].

--- a/index.html
+++ b/index.html
@@ -594,16 +594,14 @@
         </p>
         <ol class="algorithm">
           <li>Let |watchTasks:Set| be [=this=]'s
-            {{Geolocation/[[watchTasks]]}}.
-            </li>
-          <li>
-            If the [=current settings object=]'s [=associated `Document`=] is not [=fully active=]:
+          {{Geolocation/[[watchTasks]]}}.
+          </li>
+          <li>If the [=current settings object=]'s [=associated `Document`=] is
+          not [=fully active=]:
             <ol>
-              <li>
-                [=list/Empty=] |watchTasks|.
+              <li>[=list/Empty=] |watchTasks|.
               </li>
-              <li>
-                Return [=implementation-defined=] {{long}}.
+              <li>Return [=implementation-defined=] {{long}}.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -594,7 +594,18 @@
         </p>
         <ol class="algorithm">
           <li>Let |watchTasks:Set| be [=this=]'s
-          {{Geolocation/[[watchTasks]]}}.
+            {{Geolocation/[[watchTasks]]}}.
+            </li>
+          <li>
+            If the [=current settings object=]'s [=associated `Document`=] is not [=fully active=]:
+            <ol>
+              <li>
+                [=list/Empty=] |watchTasks|.
+              </li>
+              <li>
+                Return [=implementation-defined=] {{long}}.
+              </li>
+            </ol>
           </li>
           <li>Acquire a watch id.
             <ol>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     };
     </script>
   </head>
-  <body data-cite="secure-contexts permissions-policy permissions">
+  <body data-cite="secure-contexts permissions-policy permissions page-visibility-2">
     <section id="abstract">
       <p>
         The Geolocation API provides access to geographical location
@@ -639,7 +639,7 @@
                   </li>
                 </ol>
               </li>
-              <li data-cite="page-visibility-2">Wait for document to become
+              <li>Wait for document to become
               visible.
                 <ol>
                   <li>Let |document:Document| be the [=current settings

--- a/index.html
+++ b/index.html
@@ -118,6 +118,9 @@
           has received the following changes:
         </p>
         <ul>
+          <li>Added handling for when documents are not [=Document/fully
+          active=].
+          </li>
           <li>Added the [=geolocation task source=], which handles dispatching
           position updates and errors.
           </li>
@@ -591,6 +594,10 @@
           optionally (and only if |repeats| is true) a |previousId:long|.
         </p>
         <ol class="algorithm">
+          <li>If the [=current settings object=]'s [=associated `Document`=] is
+          not [=Document/fully active=], return an [=implementation-defined=]
+          {{long}}.
+          </li>
           <li>Let |watchTasks:Set| be [=this=]'s
             {{Geolocation/[[watchTasks]]}}.
             </li>
@@ -602,15 +609,6 @@
               </li>
               <li>
                 Return [=implementation-defined=] {{long}}.
-              </li>
-            </ol>
-          </li>
-          <li>If the [=current settings object=]'s [=associated `Document`=] is
-          not [=fully active=]:
-            <ol>
-              <li>[=list/Empty=] |watchTasks|.
-              </li>
-              <li>Return an [=implementation-defined=] {{long}}.
               </li>
             </ol>
           </li>
@@ -649,6 +647,9 @@
                   </li>
                   <li>If |document:Document| is [=Document/hidden=], wait for
                   the |document| to become [=Document/visible=].
+                  </li>
+                  <li>Go to <a href="#wait-for-change">wait for significant
+                  change of geographic position</a>.
                   </li>
                 </ol>
               </li>
@@ -767,10 +768,29 @@
                   </li>
                 </ol>
               </li>
-              <li>Wait for a significant change of geographic position. What
-              constitutes a significant change of geographic position is left
-              to the implementation. User agents MAY impose a rate limit on the
-              frequency position changes.
+              <li>
+                <span id="wait-for-change">Wait for a significant change of
+                geographic position</span>. What constitutes a significant
+                change of geographic position is left to the implementation.
+                User agents MAY impose a rate limit on the frequency position
+                changes.
+              </li>
+              <li>If |document| is not [=Document/fully active=] or not
+              [=Document/visible=], go back to the previous step and again
+              <a href="#wait-for-change">wait for significant change of
+              geographic position</a>.
+                <aside class="note" title=
+                "Position updates are exclusively for fully-active visible documents">
+                  <p>
+                    The desired effect here being that position updates are
+                    exclusively delivered to fully active documents that are
+                    visible; Otherwise the updates get silently "dropped on the
+                    floor". Only once a document again becomes fully active and
+                    visible (e.g., an [^iframe^] gets reattached to a parent
+                    document), do the position updates once again start getting
+                    delivered.
+                  </p>
+                </aside>
               </li>
               <li>If |watchTasks| [=list/contain|contains=] |watchId|, then:
                 <ol>

--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@
             <ol>
               <li>[=list/Empty=] |watchTasks|.
               </li>
-              <li>Return [=implementation-defined=] {{long}}.
+              <li>Return an [=implementation-defined=] {{long}}.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -592,7 +592,18 @@
         </p>
         <ol class="algorithm">
           <li>Let |watchTasks:Set| be [=this=]'s
-          {{Geolocation/[[watchTasks]]}}.
+            {{Geolocation/[[watchTasks]]}}.
+            </li>
+          <li>
+            If the [=current settings object=]'s [=associated `Document`=] is not [=fully active=]:
+            <ol>
+              <li>
+                [=list/Empty=] |watchTasks|.
+              </li>
+              <li>
+                Return [=implementation-defined=] {{long}}.
+              </li>
+            </ol>
           </li>
           <li>If the [=current settings object=]'s [=associated `Document`=] is
           not [=fully active=]:


### PR DESCRIPTION
Closes #78 

The following tasks have been completed:

 * [x] <del>Modified Web platform tests</del> - unfortunately, we don't have the capability to test this with WPT.

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://phabricator.services.mozilla.com/D117273)

cc @rakina


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/90.html" title="Last updated on Jul 13, 2021, 10:11 PM UTC (e07e3bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/90/e3f4d84...e07e3bf.html" title="Last updated on Jul 13, 2021, 10:11 PM UTC (e07e3bf)">Diff</a>