### PR TITLE
Callback with error if doc is not fully active

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
         <ol class="algorithm">
           <li>If the [=current settings object=]'s [=associated `Document`=] is
           not [=Document/fully active=], [=call back with error=]
-          |errorCallback|, {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+          |errorCallback| and {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
           </li>
           <li>Otherwise, [=request position=], passing |successCallback|,
           |errorCallback|, |options|, and (repeats) false.
@@ -569,7 +569,7 @@
           <li>If the [=current settings object=]'s [=associated `Document`=] is
           not [=Document/fully active=]:
             <ol>
-              <li>[=Call back with error=] |errorCallback|,
+              <li>[=Call back with error=] |errorCallback| and
               {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
               </li>
               <li>Return an [=implementation-defined=] {{long}}.

--- a/index.html
+++ b/index.html
@@ -544,8 +544,12 @@
           method steps are:
         </p>
         <ol class="algorithm">
-          <li>[=Request position=], passing |successCallback|, |errorCallback|,
-          |options|, and (repeats) false.
+          <li>If the [=current settings object=]'s [=associated `Document`=] is
+          not [=Document/fully active=], [=call back with error=]
+          |errorCallback|, {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+          </li>
+          <li>Otherwise, [=request position=], passing |successCallback|,
+          |errorCallback|, |options|, and (repeats) false.
           </li>
           <li>Return `undefined`.
           </li>
@@ -562,6 +566,16 @@
           method steps are:
         </p>
         <ol class="algorithm">
+          <li>If the [=current settings object=]'s [=associated `Document`=] is
+          not [=Document/fully active=]:
+            <ol>
+              <li>[=Call back with error=] |errorCallback|,
+              {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
+              </li>
+              <li>Return an [=implementation-defined=] {{long}}.
+              </li>
+            </ol>
+          </li>
           <li>Let |watchId:long| be [=request position=], passing
           |successCallback|, |errorCallback|, |options|, and (repeats) true.
           </li>
@@ -595,10 +609,6 @@
           optionally (and only if |repeats| is true) a |previousId:long|.
         </p>
         <ol class="algorithm">
-          <li>If the [=current settings object=]'s [=associated `Document`=] is
-          not [=Document/fully active=], return an [=implementation-defined=]
-          {{long}}.
-          </li>
           <li>Let |watchTasks:Set| be [=this=]'s
           {{Geolocation/[[watchTasks]]}}.
           </li>


### PR DESCRIPTION
Closes #96 

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/29799)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=228319)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1233329)
 * [x] Gecko https://phabricator.services.mozilla.com/D117273


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/97.html" title="Last updated on Jul 27, 2021, 8:29 AM UTC (b92947d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/97/f4605e5...b92947d.html" title="Last updated on Jul 27, 2021, 8:29 AM UTC (b92947d)">Diff</a>