### PR TITLE
Return 0 when watchPosition() errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,7 +573,7 @@
               <li>[=Call back with error=] |errorCallback| and
               {{GeolocationPositionError/POSITION_UNAVAILABLE}}.
               </li>
-              <li>Return an [=implementation-defined=] {{long}}.
+              <li>Return 0.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Closes #95 - @reillyeon, please see https://github.com/w3c/geolocation-api/issues/95#issuecomment-888988557 for rationale for change.  

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/29799)

Implementation commitment:

 * [ ] WebKit  - already returns `0`.
 * [ ] Chromium - already returns `0`. 
 * [X] [Gecko](https://phabricator.services.mozilla.com/D117273)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/100.html" title="Last updated on Jul 30, 2021, 1:26 AM UTC (e19aa52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/100/3d8edf8...e19aa52.html" title="Last updated on Jul 30, 2021, 1:26 AM UTC (e19aa52)">Diff</a>