### PR TITLE
Editorial: update permission policy usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
           Enabling the API in third-party contexts
         </h3>
         <p>
-          The <a>default allowlist</a> of 'self' allows Geolocation API
+          The <a>default allowlist</a> of `'self'` allows Geolocation API
           usage in same-origin nested frames but prevents third-party content
           from using the API.
         </p>
@@ -1195,7 +1195,7 @@
         The <cite>Geolocation API</cite> defines a [=policy-controlled
         feature=] identified by the string <dfn class=
         "permission">"geolocation"</dfn>. Its [=default allowlist=] is
-        'self'.
+        `'self'`.
       </p>
     </section>
     <section id="conformance"></section>

--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
           Enabling the API in third-party contexts
         </h3>
         <p>
-          The <a>default allowlist</a> of `["self"]` allows Geolocation API
+          The <a>default allowlist</a> of 'self' allows Geolocation API
           usage in same-origin nested frames but prevents third-party content
           from using the API.
         </p>
@@ -375,7 +375,7 @@
         </p>
         <aside class="example" title="Permissions Policy over HTTP">
           <pre class="http">
-            Permissions-Policy: geolocation 'none'
+            Permissions-Policy: geolocation=()
           </pre>
         </aside>
         <p>
@@ -814,6 +814,9 @@
           Check permission
         </h2>
         <p>
+          The <cite>Geolocation API</cite> is a [=default powerful feature=].
+        </p>
+        <p>
           When instructed to <dfn>check permission</dfn>, given a
           {{PositionErrorCallback}}`?` |errorCallback:PositionErrorCallback|:
         </p>
@@ -1190,8 +1193,9 @@
       </h2>
       <p>
         The <cite>Geolocation API</cite> defines a [=policy-controlled
-        feature=] identified by the string "geolocation". Its [=default
-        allowlist=] is `["self"]`.
+        feature=] identified by the string <dfn class=
+        "permission">"geolocation"</dfn>. Its [=default allowlist=] is
+        'self'.
       </p>
     </section>
     <section id="conformance"></section>


### PR DESCRIPTION
Also integrates a little bit better with Permission API, but defining itself as a "powerful feature".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/105.html" title="Last updated on Sep 30, 2021, 3:31 AM UTC (70c4611)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/105/2b82e7d...70c4611.html" title="Last updated on Sep 30, 2021, 3:31 AM UTC (70c4611)">Diff</a>