### PR TITLE
Suggest permission lifetimes

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@
           choice of [=permission/lifetimes=] vary across user agents, but they
           are typically time-based (e.g., "a day"), or until browser is closed,
           or the user might even be given the choice for the permission to be
-          remembered indefinitely. The permission [=permission/lifetimes=]
+          granted indefinitely. The permission [=permission/lifetimes=]
           dictate how long a user agent [=permission/grants=] a permission
           before that permission is automatically reverted back to its default
           [=permission state=], prompting the end-user to make a new choice.

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
           destroyed, the end-user [=navigates=] away from the [=origin=], or
           the relevant browser tab is closed. The user agent MAY also suggest
           time-based [=permission=] [=permission/lifetimes=], such as "24
-          hours", "1 week", even opt to remember the permission
+          hours", "1 week", or choose to remember the permission
           [permission/grant=] indefinitely.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -817,6 +817,16 @@
           The <cite>Geolocation API</cite> is a [=default powerful feature=].
         </p>
         <p>
+          It is RECOMMENDED that a user agent prioritize restricting the
+          [=permission=] [=permission/lifetime=] to a single session: This can
+          be, for example, until the [=environment settings object/realm=] is
+          destroyed, the end-user [=navigates=] away from the [=origin=], or
+          the relevant browser tab is closed. The user agent MAY also suggest
+          time-based [=permission=] [=permission/lifetimes=], such as "24
+          hours", "1 week", even opt to remember the permission
+          [permission/grant=] indefinitely.
+        </p>
+        <p>
           When instructed to <dfn>check permission</dfn>, given a
           {{PositionErrorCallback}}`?` |errorCallback:PositionErrorCallback|:
         </p>

--- a/index.html
+++ b/index.html
@@ -400,8 +400,8 @@
         </h3>
         <p>
           The <cite>Geolocation API</cite> is a [=powerful feature=] that
-          requires [=express permission=] from an end-user before any
-          location data is shared with a web application. This requirement is
+          requires [=express permission=] from an end-user before any location
+          data is shared with a web application. This requirement is
           normatively enforced by the [=check permission=] steps on which the
           {{Geolocation/getCurrentPosition()}} and
           {{Geolocation/watchPosition()}} methods rely.
@@ -413,11 +413,11 @@
           choice of [=permission/lifetimes=] vary across user agents, but they
           are typically time-based (e.g., "a day"), or until browser is closed,
           or the user might even be given the choice for the permission to be
-          granted indefinitely. The permission [=permission/lifetimes=]
-          dictate how long a user agent [=permission/grants=] a permission
-          before that permission is automatically reverted back to its default
-          [=permission state=], prompting the end-user to make a new choice
-          upon subsequent use.
+          granted indefinitely. The permission [=permission/lifetimes=] dictate
+          how long a user agent [=permission/grants=] a permission before that
+          permission is automatically reverted back to its default [=permission
+          state=], prompting the end-user to make a new choice upon subsequent
+          use.
         </p>
         <p>
           Although the granularity of the permission [=permission/lifetime=]
@@ -849,10 +849,10 @@
           The <cite>Geolocation API</cite> is a [=default powerful feature=].
         </p>
         <p>
-          The user agent MAY suggest
-          time-based [=permission=] [=permission/lifetimes=], such as "24
-          hours", "1 week", or choose to remember the permission
-          [permission/grant=] indefinitely. However, it is RECOMMENDED that a user agent prioritize restricting the
+          The user agent MAY suggest time-based [=permission=]
+          [=permission/lifetimes=], such as "24 hours", "1 week", or choose to
+          remember the permission [permission/grant=] indefinitely. However, it
+          is RECOMMENDED that a user agent prioritize restricting the
           [=permission=] [=permission/lifetime=] to a single session: This can
           be, for example, until the [=environment settings object/realm=] is
           destroyed, the end-user [=navigates=] away from the [=origin=], or

--- a/index.html
+++ b/index.html
@@ -849,14 +849,14 @@
           The <cite>Geolocation API</cite> is a [=default powerful feature=].
         </p>
         <p>
-          It is RECOMMENDED that a user agent prioritize restricting the
+          The user agent MAY suggest
+          time-based [=permission=] [=permission/lifetimes=], such as "24
+          hours", "1 week", or choose to remember the permission
+          [permission/grant=] indefinitely. However, it is RECOMMENDED that a user agent prioritize restricting the
           [=permission=] [=permission/lifetime=] to a single session: This can
           be, for example, until the [=environment settings object/realm=] is
           destroyed, the end-user [=navigates=] away from the [=origin=], or
-          the relevant browser tab is closed. The user agent MAY also suggest
-          time-based [=permission=] [=permission/lifetimes=], such as "24
-          hours", "1 week", or choose to remember the permission
-          [permission/grant=] indefinitely.
+          the relevant browser tab is closed.
         </p>
         <p>
           When instructed to <dfn>check permission</dfn>, given a

--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
         </h3>
         <p>
           The <cite>Geolocation API</cite> is a [=powerful feature=] that
-          requires [=express permission=] from an end-user's before any
+          requires [=express permission=] from an end-user before any
           location data is shared with a web application. This requirement is
           normatively enforced by the [=check permission=] steps on which the
           {{Geolocation/getCurrentPosition()}} and
@@ -410,7 +410,7 @@
           A end-user will generally gives [=express permission=] through a user
           interface, which usually present a range of permission
           [=permission/lifetimes=] that the end-user can choose from. The
-          choice of [=permission/lifetimes=] vary across user agent, but they
+          choice of [=permission/lifetimes=] vary across user agents, but they
           are typically time-based (e.g., "a day"), or until browser is closed,
           or the user might even be given the choice for the permission to be
           remembered indefinitely. The permission [=permission/lifetimes=]

--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
           {{Geolocation/watchPosition()}} methods rely.
         </p>
         <p>
-          A end-user will generally gives [=express permission=] through a user
+          An end-user will generally give [=express permission=] through a user
           interface, which usually present a range of permission
           [=permission/lifetimes=] that the end-user can choose from. The
           choice of [=permission/lifetimes=] vary across user agents, but they

--- a/index.html
+++ b/index.html
@@ -416,7 +416,8 @@
           granted indefinitely. The permission [=permission/lifetimes=]
           dictate how long a user agent [=permission/grants=] a permission
           before that permission is automatically reverted back to its default
-          [=permission state=], prompting the end-user to make a new choice.
+          [=permission state=], prompting the end-user to make a new choice
+          upon subsequent use.
         </p>
         <p>
           Although the granularity of the permission [=permission/lifetime=]

--- a/index.html
+++ b/index.html
@@ -394,6 +394,37 @@
         information also discloses the location of the user of the device,
         thereby potentially compromising the user's privacy.
       </p>
+      <section class="informative">
+        <h3>
+          User consent
+        </h3>
+        <p>
+          The <cite>Geolocation API</cite> is a [=powerful feature=] that
+          requires [=express permission=] from an end-user's before any
+          location data is shared with a web application. This requirement is
+          normatively enforced by the [=check permission=] steps on which the
+          {{Geolocation/getCurrentPosition()}} and
+          {{Geolocation/watchPosition()}} methods rely.
+        </p>
+        <p>
+          A end-user will generally gives [=express permission=] through a user
+          interface, which usually present a range of permission
+          [=permission/lifetimes=] that the end-user can choose from. The
+          choice of [=permission/lifetimes=] vary across user agent, but they
+          are typically time-based (e.g., "a day"), or until browser is closed,
+          or the user might even be given the choice for the permission to be
+          remembered indefinitely. The permission [=permission/lifetimes=]
+          dictate how long a user agent [=permission/grants=] a permission
+          before that permission is automatically reverted back to its default
+          [=permission state=], prompting the end-user to make a new choice.
+        </p>
+        <p>
+          Although the granularity of the permission [=permission/lifetime=]
+          varies across user-agents, this specification urges user agents to
+          limit the lifetime to a single browsing session by default (see
+          [[[#check-permission]]] for normative requirements).
+        </p>
+      </section>
       <section id="privacy_for_recipients" class="informative">
         <h3>
           Privacy considerations for recipients of location information
@@ -809,7 +840,7 @@
           </li>
         </ol>
       </section>
-      <section>
+      <section id="check-permission">
         <h2>
           Check permission
         </h2>


### PR DESCRIPTION
Closes #69 
Closes #54

Depends on https://github.com/w3c/permissions/pull/287 and https://github.com/whatwg/html/pull/7337


Try to be broadly accommodating to what browses do with respect to Geolocation permission lifetimes. I prioritized "single session" permissions, while accommodating what Chrome does (you can navigate around... only when you close the browser window/tab does it reset). I also allowed for what Brave does (time based).   

The following tasks have been completed:

 * <del>Modified Web platform tests</del> (not testable)

Implementation commitment:

 * [X] WebKit (already implemented) 
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1147918)
 * [X] Gecko (already implemented)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/108.html" title="Last updated on Nov 23, 2021, 11:29 PM UTC (d86891b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/108/9098051...d86891b.html" title="Last updated on Nov 23, 2021, 11:29 PM UTC (d86891b)">Diff</a>