### PR TITLE
Editorial: make use of HTML's page visibility change steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,17 +676,16 @@
                   </li>
                 </ol>
               </li>
-              <li>Wait for document to become visible.
+              <li>Let |document:Document| be the [=current settings object=]'s
+              [=associated Document=].
+              </li>
+              <li>If |document:Document| is [=Document/hidden=], wait for the
+              following [=page visibility change steps=]:
                 <ol>
-                  <li>Let |document:Document| be the [=current settings
-                  object=]'s [=associated Document=].
+                  <li>Assert: |document|'s [=document/visibility state=] is
+                  "visible".
                   </li>
-                  <li>If |document:Document|'s [=Document/visibility state=] is
-                  "hidden", wait for the |document|'s [=Document/visibility
-                  state=] to become "visible".
-                  </li>
-                  <li>Go to <a href="#wait-for-change">wait for significant
-                  change of geographic position</a>.
+                  <li>Continue to the next step below.
                   </li>
                 </ol>
               </li>

--- a/index.html
+++ b/index.html
@@ -679,8 +679,9 @@
               <li>Let |document:Document| be the [=current settings object=]'s
               [=associated Document=].
               </li>
-              <li>If |document:Document| is [=Document/hidden=], wait for the
-              following [=page visibility change steps=] steps to run:
+              <li>If |document:Document|'s [=Document/visibility state=] is
+              "hidden", wait for the following [=page visibility change steps=]
+              steps to run:
                 <ol>
                   <li>Assert: |document|'s [=Document/visibility state=] is
                   "visible".

--- a/index.html
+++ b/index.html
@@ -38,8 +38,7 @@
     };
     </script>
   </head>
-  <body data-cite=
-  "secure-contexts permissions-policy permissions page-visibility-2 hr-time">
+  <body data-cite="secure-contexts permissions-policy permissions hr-time html">
     <section id="abstract">
       <p>
         The Geolocation API provides access to geographical location
@@ -682,7 +681,7 @@
               <li>If |document:Document| is [=Document/hidden=], wait for the
               following [=page visibility change steps=]:
                 <ol>
-                  <li>Assert: |document|'s [=document/visibility state=] is
+                  <li>Assert: |document|'s [=Document/visibility state=] is
                   "visible".
                   </li>
                   <li>Continue to the next step below.

--- a/index.html
+++ b/index.html
@@ -38,7 +38,8 @@
     };
     </script>
   </head>
-  <body data-cite="secure-contexts permissions-policy permissions hr-time html">
+  <body data-cite=
+  "secure-contexts permissions-policy permissions hr-time html">
     <section id="abstract">
       <p>
         The Geolocation API provides access to geographical location
@@ -679,7 +680,7 @@
               [=associated Document=].
               </li>
               <li>If |document:Document| is [=Document/hidden=], wait for the
-              following [=page visibility change steps=]:
+              following [=page visibility change steps=] steps to run:
                 <ol>
                   <li>Assert: |document|'s [=Document/visibility state=] is
                   "visible".


### PR DESCRIPTION
@noamr, r? 

Noam, can you sanity check something for me... in the HTML spec, it's not really clear why the [=page visibility change steps=] take the first argument ("visible", for instance)... at least, they don't seem to be used in the steps themselves or am I missing something?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/110.html" title="Last updated on Nov 24, 2021, 1:14 AM UTC (bf06492)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/110/a1531cb...bf06492.html" title="Last updated on Nov 24, 2021, 1:14 AM UTC (bf06492)">Diff</a>