### PR TITLE
Editorial: fix "Queue a task" / "in parallel" usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
         </p>
         <ol class="algorithm">
           <li>If [=this=]'s {{Geolocation/[[watchTasks]]}}[|watchId|]
-          [=map/exists=], [=map/remove=] [=this=]'s
+          [=list/exists=], [=list/remove=] [=this=]'s
           {{Geolocation/[[watchTasks]]}}[|watchId|].
           </li>
         </ol>
@@ -655,10 +655,7 @@
           </li>
           <li>[=Set/Append=] |watchId| to |watchTasks|.
           </li>
-          <li>Let |global| be [=this=]'s [=relevant global object=].
-          </li>
-          <li>[=Queue a global task=] using the [=geolocation task source=]
-          with |global| to run the following steps [=in parallel=]:
+          <li>Return |watchId| and [=in parallel=]:
             <ol>
               <li>Do security check.
                 <ol>
@@ -668,7 +665,8 @@
                       <li>[=Call back with error=] |errorCallback| and
                       {{GeolocationPositionError/PERMISSION_DENIED}}.
                       </li>
-                      <li>[=List/Remove=] |watchId| from |watchTasks|.
+                      <li>[=Queue a task=] on the [=geolocation task source=]
+                      to [=List/remove=] |watchId| from |watchTasks|.
                       </li>
                       <li>Terminate this algorithm.
                       </li>
@@ -695,7 +693,8 @@
               [=Check permission=] passing |errorCallback|. If the check
               returns failure:
                 <ol>
-                  <li>[=List/Remove=] |watchId| from |watchTasks|.
+                  <li>[=Queue a task=] on the [=geolocation task source=] to
+                  [=List/remove=] |watchId| from |watchTasks|.
                   </li>
                   <li>Terminate this algorithm.
                   </li>
@@ -822,7 +821,8 @@
                 <ol>
                   <li>If |repeats| is false:
                     <ol>
-                      <li>[=List/Remove=] |watchId| from |watchTasks|.
+                      <li>[=Queue a task=] on the [=geolocation task source=]
+                      to [=List/remove=] |watchId| from |watchTasks|.
                       </li>
                       <li>Terminate this algorithm.
                       </li>
@@ -862,8 +862,6 @@
                 </ol>
               </li>
             </ol>
-          </li>
-          <li>Return |watchId|.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
Closes #114

I've made sure that the watchTasks are only ever touched on the main thread. 

Also dropped the global task stuff, and used "in parallel" instead (as suggested in HTML, IIUC).

@domenic, if you have time to take a look, that would be appreciated. If not, that's ok too. We appreciate your guidance thus far.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/116.html" title="Last updated on Jan 24, 2022, 8:26 AM UTC (5397e8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/116/03c9c63...5397e8d.html" title="Last updated on Jan 24, 2022, 8:26 AM UTC (5397e8d)">Diff</a>