### PR TITLE
Editorial: Fix references to "default allowlist"

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,9 +360,9 @@
           Enabling the API in third-party contexts
         </h3>
         <p>
-          The <a>default allowlist</a> of `'self'` allows Geolocation API usage
-          in same-origin nested frames but prevents third-party content from
-          using the API.
+          The [=policy-controlled feature/default allowlist=] of `'self'` allows
+          Geolocation API usage in same-origin nested frames but prevents
+          third-party content from using the API.
         </p>
         <p>
           Third-party usage can be selectively enabled by adding the
@@ -1297,7 +1297,7 @@
       <p>
         The <cite>Geolocation API</cite> defines a [=policy-controlled
         feature=] identified by the token string <a>"geolocation"</a>. Its
-        [=default allowlist=] is `'self'`.
+        [=policy-controlled feature/default allowlist=] is `'self'`.
       </p>
     </section>
     <section id="conformance"></section>


### PR DESCRIPTION
[=default allowlist=] -> [=policy-controlled feature/default allowlist=]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/133.html" title="Last updated on Mar 1, 2023, 10:21 PM UTC (c45df09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/133/a95f47a...c45df09.html" title="Last updated on Mar 1, 2023, 10:21 PM UTC (c45df09)">Diff</a>