### PR TITLE
Add `[SecureContext]` tags to the interfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
       </h2>
       <pre class="idl">
         partial interface Navigator {
-          [SameObject] readonly attribute Geolocation geolocation;
+          [SameObject, SecureContext] readonly attribute Geolocation geolocation;
         };
       </pre>
     </section>

--- a/index.html
+++ b/index.html
@@ -543,7 +543,7 @@
         `Geolocation` interface and callbacks
       </h2>
       <pre class="idl">
-        [Exposed=Window]
+        [Exposed=Window, SecureContext]
         interface Geolocation {
           undefined getCurrentPosition (
             PositionCallback successCallback,
@@ -1222,7 +1222,7 @@
         <dfn>GeolocationPositionError</dfn> interface
       </h2>
       <pre class="idl">
-        [Exposed=Window]
+        [Exposed=Window, SecureContext]
         interface GeolocationPositionError {
           const unsigned short PERMISSION_DENIED = 1;
           const unsigned short POSITION_UNAVAILABLE = 2;


### PR DESCRIPTION
- addresses https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment some syntax sections are missing the `[SecureContext]` tags so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/tr/idl/geolocation.idl#L10).

The feature has been [marked available in secure context in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation). 

The PR adds the tags to the remaining interfaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 5, 2024, 2:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/geolocation-api%23142.)._
</details>
