### PR TITLE
Correction: check for non-secure contexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,6 +695,23 @@
               </li>
             </ol>
           </li>
+          <li>
+            <aside class="correction" id="c7">
+              <span class="marker">Candidate Correction:</span> Added missing
+              step to handle [=non-secure contexts=].
+            </aside><ins cite="#c7">If |geolocation|'s [=environment settings
+            object=] is a [=non-secure context=]:
+            <ol>
+              <li>If |watchId| was passed, [=List/remove=] |watchId| from
+              |watchIDs|.
+              </li>
+              <li>[=Call back with error=] passing |errorCallback| and
+              {{GeolocationPositionError/PERMISSION_DENIED}}.
+              </li>
+              <li>Terminate this algorithm.
+              </li>
+            </ol></ins>
+          </li>
           <li>If |document:Document|'s [=Document/visibility state=] is
           "hidden", wait for the following [=page visibility change steps=] to
           run:
@@ -1293,8 +1310,14 @@
             <dfn>PERMISSION_DENIED</dfn> (numeric value 1)
           </dt>
           <dd>
-            [=Request a position=] failed because the user denied permission to
-            use the API.
+            <aside class="correction" id="c6">
+              <span class="marker">Candidate Correction:</span> Updated the
+              description of the `PERMISSION_DENIED` constant to clarify the
+              reasons for permission denial, including [=non-secure context=]
+              and user denials.
+            </aside>[=Request a position=] failed because the user denied
+            permission to use the API <ins cite="#c6">or the request was made
+            from an [=non-secure context=]</ins>.
           </dd>
           <dt>
             <dfn>POSITION_UNAVAILABLE</dfn> (numeric value 2)


### PR DESCRIPTION
Closes #156 

The following tasks have been completed:

 * [ ] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/blob/master/geolocation-API/non-secure-contexts.http.html)

Implementation commitment (and no objections):

 * [X] WebKit
 * [X] Chromium
 * [X] Gecko


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/157.html" title="Last updated on Jun 4, 2024, 2:25 AM UTC (e3048dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/157/664f556...e3048dd.html" title="Last updated on Jun 4, 2024, 2:25 AM UTC (e3048dd)">Diff</a>