### PR TITLE
Disable /TR/ publication for errata.html

### DIFF
--- a/.github/workflows/auto-publish-errata.yml
+++ b/.github/workflows/auto-publish-errata.yml
@@ -21,6 +21,3 @@ jobs:
           VALIDATE_LINKS: false
           VALIDATE_PUBRULES: false
           GH_PAGES_BRANCH: gh-pages
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-device-apis/2021May/0008.html"
-          W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"

--- a/errata.html
+++ b/errata.html
@@ -26,7 +26,7 @@
           },
         ],
         latestVersion: null,
-        group: [ "das", "webapss" ],
+        group: [ "das", "webapps" ],
         format: "markdown",
         logos: [
             {

--- a/errata.html
+++ b/errata.html
@@ -18,8 +18,15 @@
             companyURL: "https://apple.com",
             w3cid: 39125,
           },
+          {
+            name: "Reilly Grant",
+            company: "Google",
+            companyURL: "https://google.com",
+            w3cid: "83788",
+          },
         ],
         latestVersion: null,
+        group: [ "das", "webapss" ],
         format: "markdown",
         logos: [
             {
@@ -45,10 +52,10 @@
 
     ## Process for submitting errata
 
-    Please [file an issue](https://github.com/w3c/payment-request/issues) on Github.
+    Please [file an issue](https://github.com/w3c/geolocation-api/issues/new) on Github.
 
     ## Unaddressed errata
-    [See issues on Github](https://github.com/w3c/payment-request/issues)
+    [See issues on Github](https://github.com/w3c/geolocation-api/labels/errata)
 
     ## Errata approved by the Working Group
     <script class="removeOnSave">


### PR DESCRIPTION
This will solve recent PR merge check issues, with removing W3C_ lines.
Also fixed errata.html on wrong repository name, etc.

Background:

- built spec page (Overview.html) points to errata.html at github.io but not in the same directory in /TR/
- there seems no available specStatus configuration of respec, which could be published to /TR/, like base nor LD
- even if we want to publish errata.html into /TR/ we shall run echidna publication at once contains both Overview.html and errata.html (but not running spec-prod twice)
