### PR TITLE
Editorial: Minor corrections prior to republication

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
           </pre>
         </aside>
       </section>
-      <section>
+      <section class="informative">
         <h2>
           Using `timeout`
         </h2>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
         <aside class="example" title="Using clearWatch()">
           <pre class="js">
             const watchId = navigator.geolocation.watchPosition(
-              position =&gt; console.log(position)
+              position =&gt; console.log(position);
             );
 
             function buttonClickHandler() {

--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@
               error handling within geolocation retrieval.
             </aside><del cite="#c1">If the [=current settings object=]'s
             [=relevant global object=]'s [=associated `Document`=] is not
-            [=Document/fully active=]:</del> <ins cite="#c1">If the [=this=]'s
+            [=Document/fully active=]:</del> <ins cite="#c1">If [=this=]'s
             [=relevant global object=]'s [=associated `Document`=] is not
             [=Document/fully active=]:</ins>
             <ol>
@@ -623,7 +623,7 @@
               document's activity status.
             </aside><del cite="#c2">If the [=current settings object=]'s
             [=relevant global object=]'s [=associated `Document`=] is not
-            [=Document/fully active=]:</del> <ins cite="#c2">If the [=this=]'s
+            [=Document/fully active=]:</del> <ins cite="#c2">If [=this=]'s
             [=relevant global object=]'s [=associated `Document`=] is not
             [=Document/fully active=]:</ins>
             <ol>


### PR DESCRIPTION
This PR contains a set of minor editorial corrections which should be applied prior to republication:

* Adds a missing semicolon to the `clearWatch()` example.
* Adds a missing "informative" class to the `timeout` example.
* Removes two unnecessary instances of the word "the" from the proposed changes to the fully active checks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/161.html" title="Last updated on Jun 11, 2024, 7:57 PM UTC (32f2ab8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/161/12327c4...32f2ab8.html" title="Last updated on Jun 11, 2024, 7:57 PM UTC (32f2ab8)">Diff</a>