### PR TITLE
Addition: Define units for accuracy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1138,13 +1138,19 @@
           according to the [[WGS84]] geodetic system, instead of just stating
           "decimal degrees."
         </aside>
+        <aside class="addition" id="a3">
+          <span class="marker">Candidate Correction:</span> To improve clarity
+          and precision, a description of the accuracy attribute has been added,
+          defining it as meters of radius.
+        </aside>
         <p>
           <del cite="#c3">The <strong>latitude</strong> and
           <strong>longitude</strong> attributes are geographic coordinates
           specified in decimal degrees.</del> <ins cite="#c3">The
           <dfn>latitude</dfn> and <dfn>longitude</dfn> attributes denote the
           position, specified as a real number of degrees, in the [[WGS84]]
-          coordinate system.</ins>
+          coordinate system.</ins> <ins cite="#a3">The <dfn>accuracy</dfn>
+          attribute denotes the position accuracy radius in meters.</ins>
         </p>
       </section>
       <section>


### PR DESCRIPTION
As with altitudeAccuracy, implementations provide this value in meters and that is what MDN documents but this was not specified.

Fixed #160.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/pull/162.html" title="Last updated on Jun 11, 2024, 8:15 PM UTC (bded772)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-api/162/12327c4...bded772.html" title="Last updated on Jun 11, 2024, 8:15 PM UTC (bded772)">Diff</a>